### PR TITLE
Added get_bpm

### DIFF
--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -77,28 +77,27 @@ impl MidiImpl of MidiTrait {
         // Iterate through the MIDI events, find and return the SetTempo message
         let mut ev = self.clone().events;
         let mut outtempo: u32 = 0;
-        let mut i = 0;
 
         loop {
-            if i == ev.len() {
-                break;
-            }
-
-            let currentevent = ev.at(i);
-
-            match currentevent {
-                Message::NOTE_ON(NoteOn) => {},
-                Message::NOTE_OFF(NoteOff) => {},
-                Message::SET_TEMPO(SetTempo) => {
-                    outtempo = *SetTempo.tempo;
+            match ev.pop_front() {
+                Option::Some(currentevent) => {
+                    match currentevent {
+                        Message::NOTE_ON(NoteOn) => {},
+                        Message::NOTE_OFF(NoteOff) => {},
+                        Message::SET_TEMPO(SetTempo) => {
+                            outtempo = *SetTempo.tempo;
+                        },
+                        Message::TIME_SIGNATURE(TimeSignature) => {},
+                        Message::CONTROL_CHANGE(ControlChange) => {},
+                        Message::PITCH_WHEEL(PitchWheel) => {},
+                        Message::AFTER_TOUCH(AfterTouch) => {},
+                        Message::POLY_TOUCH(PolyTouch) => {},
+                    }
                 },
-                Message::TIME_SIGNATURE(TimeSignature) => {},
-                Message::CONTROL_CHANGE(ControlChange) => {},
-                Message::PITCH_WHEEL(PitchWheel) => {},
-                Message::AFTER_TOUCH(AfterTouch) => {},
-                Message::POLY_TOUCH(PolyTouch) => {},
-            }
-            i += 1;
+                Option::None(_) => {
+                    break;
+                }
+            };
         };
 
         outtempo

--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -74,7 +74,34 @@ impl MidiImpl of MidiTrait {
     }
 
     fn get_bpm(self: @Midi) -> u32 {
-        panic(array!['not supported yet'])
+        // Iterate through the MIDI events, find and return the SetTempo message
+        let mut ev = self.clone().events;
+        let mut outtempo: u32 = 0;
+        let mut i = 0;
+
+        loop {
+            if i == ev.len() {
+                break;
+            }
+
+            let currentevent = ev.at(i);
+
+            match currentevent {
+                Message::NOTE_ON(NoteOn) => {},
+                Message::NOTE_OFF(NoteOff) => {},
+                Message::SET_TEMPO(SetTempo) => {
+                    outtempo = *SetTempo.tempo;
+                },
+                Message::TIME_SIGNATURE(TimeSignature) => {},
+                Message::CONTROL_CHANGE(ControlChange) => {},
+                Message::PITCH_WHEEL(PitchWheel) => {},
+                Message::AFTER_TOUCH(AfterTouch) => {},
+                Message::POLY_TOUCH(PolyTouch) => {},
+            }
+            i += 1;
+        };
+
+        outtempo
     }
 
     fn generate_harmony(self: @Midi, modes: Modes) -> Midi {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Added get_bpm. Current implementation returns last tempo message, else 0 - May be best to allow returning n tempos or tempos at a given time
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Retrieves Tempo message from MIDI eventlist
Issue Number: #11 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->