### PR TITLE
Added change_tempo

### DIFF
--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -88,7 +88,7 @@ impl MidiImpl of MidiTrait {
                         },
                         Message::SET_TEMPO(SetTempo) => {
                             // Create a new SetTempo message with the updated tempo
-                            let tempo = SetTempo { tempo: new_tempo, time: Option::None };
+                            let tempo = SetTempo { tempo: new_tempo, time: *SetTempo.time };
                             let tempomessage = Message::SET_TEMPO((tempo));
                             eventlist.append(tempomessage);
                         },

--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -68,52 +68,55 @@ impl MidiImpl of MidiTrait {
     }
 
     fn change_tempo(self: @Midi, new_tempo: u32) -> Midi {
-        // Iterate through the MIDI events and update the SetTempo messages
+        // Create a clone of the MIDI events
         let mut ev = self.clone().events;
 
-        //create output event list and tempo data to test
+        // Create a new array to store the modified events
         let mut eventlist = ArrayTrait::<Message>::new();
 
-        let tempo = SetTempo { tempo: new_tempo, time: Option::None };
-        let tempomessage = Message::SET_TEMPO((tempo));
-
-        let mut i = 0;
         loop {
-            if i == ev.len() {
-                break;
-            }
-
-            let currentevent = ev.at(i);
-
-            match currentevent {
-                Message::NOTE_ON(NoteOn) => {
-                    eventlist.append(*currentevent);
+            // Use pop_front to get the next event
+            match ev.pop_front() {
+                Option::Some(currentevent) => {
+                    // Process the current event
+                    match currentevent {
+                        Message::NOTE_ON(NoteOn) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::NOTE_OFF(NoteOff) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::SET_TEMPO(SetTempo) => {
+                            // Create a new SetTempo message with the updated tempo
+                            let tempo = SetTempo { tempo: new_tempo, time: Option::None };
+                            let tempomessage = Message::SET_TEMPO((tempo));
+                            eventlist.append(tempomessage);
+                        },
+                        Message::TIME_SIGNATURE(TimeSignature) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::CONTROL_CHANGE(ControlChange) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::PITCH_WHEEL(PitchWheel) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::AFTER_TOUCH(AfterTouch) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::POLY_TOUCH(PolyTouch) => {
+                            eventlist.append(*currentevent);
+                        },
+                    }
                 },
-                Message::NOTE_OFF(NoteOff) => {
-                    eventlist.append(*currentevent);
-                },
-                Message::SET_TEMPO(SetTempo) => {
-                    eventlist.append(tempomessage);
-                },
-                Message::TIME_SIGNATURE(TimeSignature) => {
-                    eventlist.append(*currentevent);
-                },
-                Message::CONTROL_CHANGE(ControlChange) => {
-                    eventlist.append(*currentevent);
-                },
-                Message::PITCH_WHEEL(PitchWheel) => {
-                    eventlist.append(*currentevent);
-                },
-                Message::AFTER_TOUCH(AfterTouch) => {
-                    eventlist.append(*currentevent);
-                },
-                Message::POLY_TOUCH(PolyTouch) => {
-                    eventlist.append(*currentevent);
-                },
-            }
-            i += 1;
+                Option::None(_) => {
+                    // If there are no more events, break out of the loop
+                    break;
+                }
+            };
         };
 
+        // Create a new Midi object with the modified event list
         Midi { events: eventlist.span() }
     }
 

--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -1,7 +1,9 @@
 use orion::operators::tensor::{Tensor, U32Tensor,};
 use orion::numbers::i32;
 
-use koji::midi::types::{Midi, Message, Modes, ArpPattern, VelocityCurve};
+use koji::midi::types::{
+    Midi, Message, Modes, ArpPattern, VelocityCurve, SetTempo, TimeSignature, NoteOn
+};
 
 trait MidiTrait {
     /// =========== NOTE MANIPULATION ===========
@@ -66,7 +68,53 @@ impl MidiImpl of MidiTrait {
     }
 
     fn change_tempo(self: @Midi, new_tempo: u32) -> Midi {
-        panic(array!['not supported yet'])
+        // Iterate through the MIDI events and update the SetTempo messages
+        let mut ev = self.clone().events;
+
+        //create output event list and tempo data to test
+        let mut eventlist = ArrayTrait::<Message>::new();
+
+        let tempo = SetTempo { tempo: new_tempo, time: Option::None };
+        let tempomessage = Message::SET_TEMPO((tempo));
+
+        let mut i = 0;
+        loop {
+            if i == ev.len() {
+                break;
+            }
+
+            let currentevent = ev.at(i);
+
+            match currentevent {
+                Message::NOTE_ON(NoteOn) => {
+                    eventlist.append(*currentevent);
+                },
+                Message::NOTE_OFF(NoteOff) => {
+                    eventlist.append(*currentevent);
+                },
+                Message::SET_TEMPO(SetTempo) => {
+                    eventlist.append(tempomessage);
+                },
+                Message::TIME_SIGNATURE(TimeSignature) => {
+                    eventlist.append(*currentevent);
+                },
+                Message::CONTROL_CHANGE(ControlChange) => {
+                    eventlist.append(*currentevent);
+                },
+                Message::PITCH_WHEEL(PitchWheel) => {
+                    eventlist.append(*currentevent);
+                },
+                Message::AFTER_TOUCH(AfterTouch) => {
+                    eventlist.append(*currentevent);
+                },
+                Message::POLY_TOUCH(PolyTouch) => {
+                    eventlist.append(*currentevent);
+                },
+            }
+            i += 1;
+        };
+
+        Midi { events: eventlist.span() }
     }
 
     fn remap_instruments(self: @Midi, chanel: u32) -> Midi {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Feature enables changing tempo messages to new value in a MIDI eventlist. Currently sets the time: Option<FP32x32> value to none for now but that may need to be fleshed out.
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Iterates through the MIDI events and updates any SetTempo messages to the specified tempo.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->