### PR TITLE
Added extract_notes

### DIFF
--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -60,65 +60,57 @@ impl MidiImpl of MidiTrait {
     }
 
     fn extract_notes(self: @Midi, note_range: usize) -> Midi {
-        /// Extract notes within a specified pitch range from middle c
         let mut ev = self.clone().events;
-        let mut currentnote: u8 = 0;
 
-        //note range is defined as +- middlec. EG note_range== 12 -> 48 - 72
         let middlec = 60;
         let mut lowerbound = 0;
         let mut upperbound = 127;
 
-        if (note_range < middlec) {
+        if note_range < middlec {
             lowerbound = middlec - note_range;
         }
-        if ((note_range + middlec) < 127) {
+        if note_range + middlec < 127 {
             upperbound = middlec + note_range;
         }
 
-        let mut i = 0;
-
-        //create output event list and tempo data to test
         let mut eventlist = ArrayTrait::<Message>::new();
 
         loop {
-            if i == ev.len() {
-                break;
-            }
-
-            let currentevent = ev.at(i);
-
-            match currentevent {
-                Message::NOTE_ON(NoteOn) => {
-                    let currentnoteon = *NoteOn.note;
-
-                    if (currentnoteon > lowerbound.try_into().unwrap()) {
-                        if (currentnoteon < upperbound.try_into().unwrap()) {
-                            eventlist.append(*currentevent);
-                        }
+            match ev.pop_front() {
+                Option::Some(currentevent) => {
+                    match currentevent {
+                        Message::NOTE_ON(NoteOn) => {
+                            let currentnoteon = *NoteOn.note;
+                            if currentnoteon > lowerbound.try_into().unwrap()
+                                && currentnoteon < upperbound.try_into().unwrap() {
+                                eventlist.append(*currentevent);
+                            }
+                        },
+                        Message::NOTE_OFF(NoteOff) => {
+                            let currentnoteoff = *NoteOff.note;
+                            if currentnoteoff > lowerbound.try_into().unwrap()
+                                && currentnoteoff < upperbound.try_into().unwrap() {
+                                eventlist.append(*currentevent);
+                            }
+                        },
+                        Message::SET_TEMPO(SetTempo) => {},
+                        Message::TIME_SIGNATURE(TimeSignature) => {},
+                        Message::CONTROL_CHANGE(ControlChange) => {},
+                        Message::PITCH_WHEEL(PitchWheel) => {},
+                        Message::AFTER_TOUCH(AfterTouch) => {},
+                        Message::POLY_TOUCH(PolyTouch) => {},
                     }
                 },
-                Message::NOTE_OFF(NoteOff) => {
-                    let currentnoteoff = *NoteOff.note;
-
-                    if (currentnoteoff > lowerbound.try_into().unwrap()) {
-                        if (currentnoteoff < upperbound.try_into().unwrap()) {
-                            eventlist.append(*currentevent);
-                        }
-                    }
-                },
-                Message::SET_TEMPO(SetTempo) => {},
-                Message::TIME_SIGNATURE(TimeSignature) => {},
-                Message::CONTROL_CHANGE(ControlChange) => {},
-                Message::PITCH_WHEEL(PitchWheel) => {},
-                Message::AFTER_TOUCH(AfterTouch) => {},
-                Message::POLY_TOUCH(PolyTouch) => {},
-            }
-            i += 1;
+                Option::None(_) => {
+                    break;
+                }
+            };
         };
 
+        // Create a new Midi object with the modified event list
         Midi { events: eventlist.span() }
     }
+
 
     fn change_note_duration(self: @Midi, factor: i32) -> Midi {
         panic(array!['not supported yet'])


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Iterates through MIDI events and collects all NoteOn and NoteOff messages within a specified range. 
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Extract notes within a specified pitch range from middle c. 
Note range is defined as +- middlec (keynum 60). EG note_range== 12 -> 48 - 72
To enable more specific data slicing, I could imagine changing note_range to two arguments: lower_bound and upper_bound
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->