### PR TITLE
Quantize Note Implementation

### DIFF
--- a/src/midi.cairo
+++ b/src/midi.cairo
@@ -1,2 +1,3 @@
 mod core;
 mod types;
+mod time;

--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -1,7 +1,8 @@
 use orion::operators::tensor::{Tensor, U32Tensor,};
-use orion::numbers::i32;
+use orion::numbers::{FP32x32, i32};
 
-use koji::midi::types::{Midi, Message, Modes, ArpPattern, VelocityCurve};
+use koji::midi::types::{Midi, Message, Modes, ArpPattern, VelocityCurve, NoteOn, NoteOff};
+use koji::midi::time::round_to_nearest_nth;
 
 trait MidiTrait {
     /// =========== NOTE MANIPULATION ===========
@@ -55,7 +56,61 @@ impl MidiImpl of MidiTrait {
     }
 
     fn quantize_notes(self: @Midi, grid_size: usize) -> Midi {
-        panic(array!['not supported yet'])
+        let mut ev = self.clone().events;
+        let mut eventlist = ArrayTrait::<Message>::new();
+
+        loop {
+            match ev.pop_front() {
+                Option::Some(currentevent) => {
+                    match currentevent {
+                        Message::NOTE_ON(NoteOn) => {
+                            let newnote = NoteOn {
+                                channel: *NoteOn.channel,
+                                note: *NoteOn.note,
+                                velocity: *NoteOn.velocity,
+                                time: round_to_nearest_nth(*NoteOn.time, grid_size)
+                            };
+                            let notemessage = Message::NOTE_ON((newnote));
+                            eventlist.append(notemessage);
+                        },
+                        Message::NOTE_OFF(NoteOff) => {
+                            let newnote = NoteOff {
+                                channel: *NoteOff.channel,
+                                note: *NoteOff.note,
+                                velocity: *NoteOff.velocity,
+                                time: round_to_nearest_nth(*NoteOff.time, grid_size)
+                            };
+                            let notemessage = Message::NOTE_OFF((newnote));
+                            eventlist.append(notemessage);
+                        },
+                        Message::SET_TEMPO(SetTempo) => {
+                            eventlist.append(*currentevent)
+                        },
+                        Message::TIME_SIGNATURE(TimeSignature) => {
+                            eventlist.append(*currentevent)
+                        },
+                        Message::CONTROL_CHANGE(ControlChange) => {
+                            eventlist.append(*currentevent)
+                        },
+                        Message::PITCH_WHEEL(PitchWheel) => {
+                            eventlist.append(*currentevent)
+                        },
+                        Message::AFTER_TOUCH(AfterTouch) => {
+                            eventlist.append(*currentevent)
+                        },
+                        Message::POLY_TOUCH(PolyTouch) => {
+                            eventlist.append(*currentevent)
+                        },
+                    }
+                },
+                Option::None(_) => {
+                    break;
+                }
+            };
+        };
+
+        // Create a new Midi object with the modified event list
+        Midi { events: eventlist.span() }
     }
 
     fn extract_notes(self: @Midi, note_range: usize) -> Midi {

--- a/src/midi/time.cairo
+++ b/src/midi/time.cairo
@@ -1,0 +1,15 @@
+use orion::numbers::FP32x32;
+
+fn round_to_nearest_nth(time: FP32x32, grid_resolution: usize) -> FP32x32 {
+    let newgridres: u64 = grid_resolution.into();
+    let rounded = ((time.mag / newgridres) * newgridres);
+
+    let remainder = time.mag - rounded;
+    let half_resolution = newgridres / 2;
+
+    if remainder >= half_resolution {
+        FP32x32 { mag: (rounded + newgridres), sign: time.sign }
+    } else {
+        FP32x32 { mag: rounded, sign: time.sign }
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
[Link](https://github.com/cienicera/Koji/blob/eb3e5a1451a3446b7ae1b060507cc6e48f370658/src/midi/core.cairo#L58) to implementation.
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Currently rounds the .time value for a NoteOn/NoteOff struct to an arbitrary grid size.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->