### PR TITLE
Reverse Notes

### DIFF
--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -56,11 +56,6 @@ impl MidiImpl of MidiTrait {
         panic(array!['not supported yet'])
     }
 
-    // Reverse notes by finding the last and first message times and applying 
-    // the following computation to every time value: (lastmsgtime - currenttime) + firstmsgtime
-    // Additionally, NoteOn msgs need to be swapped as NoteOffs and visa versa
-    // Note: Possible optimization?
-
     fn reverse_notes(self: @Midi) -> Midi {
         let mut ev = self.clone().events;
         let mut rev = self.clone().events.reverse().span();

--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -1,7 +1,13 @@
 use orion::operators::tensor::{Tensor, U32Tensor,};
-use orion::numbers::i32;
+use orion::numbers::{i32, FP32x32};
+use core::option::OptionTrait;
+use koji::midi::types::{
+    Midi, Message, Modes, ArpPattern, VelocityCurve, NoteOn, NoteOff, SetTempo, TimeSignature,
+    ControlChange, PitchWheel, AfterTouch, PolyTouch
+};
+use alexandria_data_structures::stack::{StackTrait, Felt252Stack, NullableStack};
+use alexandria_data_structures::array_ext::{ArrayTraitExt, SpanTraitExt};
 
-use koji::midi::types::{Midi, Message, Modes, ArpPattern, VelocityCurve};
 
 trait MidiTrait {
     /// =========== NOTE MANIPULATION ===========
@@ -50,8 +56,201 @@ impl MidiImpl of MidiTrait {
         panic(array!['not supported yet'])
     }
 
+    // Reverse notes by finding the last and first message times and applying 
+    // the following computation to every time value: (lastmsgtime - currenttime) + firstmsgtime
+    // Additionally, NoteOn msgs need to be swapped as NoteOffs and visa versa
+    // Note: Possible optimization?
+
     fn reverse_notes(self: @Midi) -> Midi {
-        panic(array!['not supported yet'])
+        let mut ev = self.clone().events;
+        let mut rev = self.clone().events.reverse().span();
+        let lastmsgtime = rev.pop_front();
+        let firstmsgtime = ev.pop_front();
+        let mut maxtime = FP32x32 { mag: 0, sign: false };
+        let mut mintime = FP32x32 { mag: 0, sign: false };
+        let mut eventlist = ArrayTrait::<Message>::new();
+
+        //assign maxtime to the last message's time value in the Midi
+        match lastmsgtime {
+            Option::Some(currentev) => {
+                match currentev {
+                    Message::NOTE_ON(NoteOn) => {
+                        maxtime = *NoteOn.time;
+                    },
+                    Message::NOTE_OFF(NoteOff) => {
+                        maxtime = *NoteOff.time;
+                    },
+                    Message::SET_TEMPO(SetTempo) => {
+                        match *SetTempo.time {
+                            Option::Some(time) => {
+                                maxtime = time;
+                            },
+                            Option::None => {},
+                        }
+                    },
+                    Message::TIME_SIGNATURE(TimeSignature) => {
+                        match *TimeSignature.time {
+                            Option::Some(time) => {
+                                maxtime = time;
+                            },
+                            Option::None => {},
+                        }
+                    },
+                    Message::CONTROL_CHANGE(ControlChange) => {
+                        maxtime = *ControlChange.time;
+                    },
+                    Message::PITCH_WHEEL(PitchWheel) => {
+                        maxtime = *PitchWheel.time;
+                    },
+                    Message::AFTER_TOUCH(AfterTouch) => {
+                        maxtime = *AfterTouch.time;
+                    },
+                    Message::POLY_TOUCH(PolyTouch) => {
+                        maxtime = *PolyTouch.time;
+                    },
+                }
+            },
+            Option::None(_) => {}
+        };
+
+        //assign mintime to the first message's time value
+        match firstmsgtime {
+            Option::Some(currentev) => {
+                match currentev {
+                    Message::NOTE_ON(NoteOn) => {
+                        mintime = *NoteOn.time;
+                    },
+                    Message::NOTE_OFF(NoteOff) => {
+                        mintime = *NoteOff.time;
+                    },
+                    Message::SET_TEMPO(SetTempo) => {
+                        match *SetTempo.time {
+                            Option::Some(time) => {
+                                mintime = time;
+                            },
+                            Option::None => {},
+                        }
+                    },
+                    Message::TIME_SIGNATURE(TimeSignature) => {
+                        match *TimeSignature.time {
+                            Option::Some(time) => {
+                                mintime = time;
+                            },
+                            Option::None => {},
+                        }
+                    },
+                    Message::CONTROL_CHANGE(ControlChange) => {
+                        mintime = *ControlChange.time;
+                    },
+                    Message::PITCH_WHEEL(PitchWheel) => {
+                        mintime = *PitchWheel.time;
+                    },
+                    Message::AFTER_TOUCH(AfterTouch) => {
+                        mintime = *AfterTouch.time;
+                    },
+                    Message::POLY_TOUCH(PolyTouch) => {
+                        mintime = *PolyTouch.time;
+                    },
+                }
+            },
+            Option::None(_) => {}
+        };
+
+        loop {
+            match rev.pop_front() {
+                Option::Some(currentevent) => {
+                    match currentevent {
+                        Message::NOTE_ON(NoteOn) => {
+                            let newnote = NoteOff {
+                                channel: *NoteOn.channel,
+                                note: *NoteOn.note,
+                                velocity: *NoteOn.velocity,
+                                time: ((maxtime - *NoteOn.time) + mintime)
+                            };
+                            let notemessage = Message::NOTE_OFF((newnote));
+                            eventlist.append(notemessage);
+                        },
+                        Message::NOTE_OFF(NoteOff) => {
+                            let newnote = NoteOn {
+                                channel: *NoteOff.channel,
+                                note: *NoteOff.note,
+                                velocity: *NoteOff.velocity,
+                                time: (maxtime - *NoteOff.time) + mintime
+                            };
+                            let notemessage = Message::NOTE_ON((newnote));
+                            eventlist.append(notemessage);
+                        },
+                        Message::SET_TEMPO(SetTempo) => {
+                            let scaledtempo = SetTempo {
+                                tempo: *SetTempo.tempo,
+                                time: match *SetTempo.time {
+                                    Option::Some(time) => Option::Some((maxtime - time) + mintime),
+                                    Option::None => Option::None,
+                                }
+                            };
+                            let tempomessage = Message::SET_TEMPO((scaledtempo));
+                            eventlist.append(tempomessage);
+                        },
+                        Message::TIME_SIGNATURE(TimeSignature) => {
+                            let newtimesig = TimeSignature {
+                                numerator: *TimeSignature.numerator,
+                                denominator: *TimeSignature.denominator,
+                                clocks_per_click: *TimeSignature.clocks_per_click,
+                                time: match *TimeSignature.time {
+                                    Option::Some(time) => Option::Some((maxtime - time) + mintime),
+                                    Option::None => Option::None,
+                                }
+                            };
+                            let tsmessage = Message::TIME_SIGNATURE((newtimesig));
+                            eventlist.append(tsmessage);
+                        },
+                        Message::CONTROL_CHANGE(ControlChange) => {
+                            let newcontrolchange = ControlChange {
+                                channel: *ControlChange.channel,
+                                control: *ControlChange.control,
+                                value: *ControlChange.value,
+                                time: (maxtime - *ControlChange.time) + mintime
+                            };
+                            let ccmessage = Message::CONTROL_CHANGE((newcontrolchange));
+                            eventlist.append(ccmessage);
+                        },
+                        Message::PITCH_WHEEL(PitchWheel) => {
+                            let newpitchwheel = PitchWheel {
+                                channel: *PitchWheel.channel,
+                                pitch: *PitchWheel.pitch,
+                                time: (maxtime - *PitchWheel.time) + mintime
+                            };
+                            let pwmessage = Message::PITCH_WHEEL((newpitchwheel));
+                            eventlist.append(pwmessage);
+                        },
+                        Message::AFTER_TOUCH(AfterTouch) => {
+                            let newaftertouch = AfterTouch {
+                                channel: *AfterTouch.channel,
+                                value: *AfterTouch.value,
+                                time: (maxtime - *AfterTouch.time) + mintime
+                            };
+                            let atmessage = Message::AFTER_TOUCH((newaftertouch));
+                            eventlist.append(atmessage);
+                        },
+                        Message::POLY_TOUCH(PolyTouch) => {
+                            let newpolytouch = PolyTouch {
+                                channel: *PolyTouch.channel,
+                                note: *PolyTouch.note,
+                                value: *PolyTouch.value,
+                                time: (maxtime - *PolyTouch.time) + mintime
+                            };
+                            let ptmessage = Message::POLY_TOUCH((newpolytouch));
+                            eventlist.append(ptmessage);
+                        },
+                    }
+                },
+                Option::None(_) => {
+                    break;
+                }
+            };
+        };
+
+        Midi { events: eventlist.span() }
     }
 
     fn quantize_notes(self: @Midi, grid_size: usize) -> Midi {
@@ -89,4 +288,3 @@ impl MidiImpl of MidiTrait {
         panic(array!['not supported yet'])
     }
 }
-


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Reverse the order of note and midi messages by finding the last and first message times and applying the following computation to every time value: (lastmsgtime - currenttime) + firstmsgtime. Additionally, NoteOn msgs need to be swapped as NoteOffs and visa versa

Note: This might not be the most optimized version - Perhaps I should avoid use of the reverse function via ArrayTraitExt, SpanTraitExt?

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->