### PR TITLE
generate-harmony implementation w/ pitchclass fix

### DIFF
--- a/src/midi.cairo
+++ b/src/midi.cairo
@@ -1,3 +1,5 @@
 mod core;
 mod types;
 mod time;
+mod modes;
+mod pitch;

--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -3,9 +3,11 @@ use orion::numbers::{i32, FP32x32};
 use core::option::OptionTrait;
 use koji::midi::types::{
     Midi, Message, Modes, ArpPattern, VelocityCurve, NoteOn, NoteOff, SetTempo, TimeSignature,
-    ControlChange, PitchWheel, AfterTouch, PolyTouch
+    ControlChange, PitchWheel, AfterTouch, PolyTouch, Direction, PitchClass
 };
 use koji::midi::time::round_to_nearest_nth;
+use koji::midi::modes::{mode_steps};
+use koji::midi::pitch::{PitchClassTrait, keynum_to_pc};
 
 trait MidiTrait {
     /// =========== NOTE MANIPULATION ===========
@@ -34,7 +36,7 @@ trait MidiTrait {
     /// Return statistics about notes (e.g., most frequent note, average note duration).
     /// =========== ADVANCED MANIPULATION ===========
     /// Add harmonies to existing melodies based on specified intervals.
-    fn generate_harmony(self: @Midi, modes: Modes) -> Midi;
+    fn generate_harmony(self: @Midi, steps: i32, tonic: PitchClass, modes: Modes) -> Midi;
     /// Convert chords into arpeggios based on a given pattern.
     fn arpeggiate_chords(self: @Midi, pattern: ArpPattern) -> Midi;
     /// Add or modify dynamics (velocity) of notes based on a specified curve or pattern.
@@ -424,8 +426,92 @@ impl MidiImpl of MidiTrait {
         outtempo
     }
 
-    fn generate_harmony(self: @Midi, modes: Modes) -> Midi {
-        panic(array!['not supported yet'])
+    fn generate_harmony(self: @Midi, steps: i32, tonic: PitchClass, modes: Modes) -> Midi {
+        let mut ev = self.clone().events;
+        let mut eventlist = ArrayTrait::<Message>::new();
+        let currentmode = mode_steps(modes);
+
+        loop {
+            match ev.pop_front() {
+                Option::Some(currentevent) => {
+                    match currentevent {
+                        Message::NOTE_ON(NoteOn) => {
+                            let outnote = if steps.sign {
+                                keynum_to_pc(*NoteOn.note)
+                                    .modal_transposition(
+                                        tonic,
+                                        currentmode,
+                                        steps.mag.try_into().unwrap(),
+                                        Direction::Up(())
+                                    )
+                            } else {
+                                keynum_to_pc(*NoteOn.note)
+                                    .modal_transposition(
+                                        tonic,
+                                        currentmode,
+                                        steps.mag.try_into().unwrap(),
+                                        Direction::Down(())
+                                    )
+                            };
+
+                            let newnote = NoteOn {
+                                channel: *NoteOn.channel,
+                                note: outnote,
+                                velocity: *NoteOn.velocity,
+                                time: *NoteOn.time
+                            };
+
+                            let notemessage = Message::NOTE_ON((newnote));
+                            eventlist.append(notemessage);
+                            //include original note
+                            eventlist.append(*currentevent);
+                        },
+                        Message::NOTE_OFF(NoteOff) => {
+                            let outnote = if steps.sign {
+                                *NoteOff.note - steps.mag.try_into().unwrap()
+                            } else {
+                                *NoteOff.note + steps.mag.try_into().unwrap()
+                            };
+
+                            let newnote = NoteOff {
+                                channel: *NoteOff.channel,
+                                note: outnote,
+                                velocity: *NoteOff.velocity,
+                                time: *NoteOff.time
+                            };
+
+                            let notemessage = Message::NOTE_OFF((newnote));
+                            eventlist.append(notemessage);
+                            //include original note
+                            eventlist.append(*currentevent);
+                        },
+                        Message::SET_TEMPO(SetTempo) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::TIME_SIGNATURE(TimeSignature) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::CONTROL_CHANGE(ControlChange) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::PITCH_WHEEL(PitchWheel) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::AFTER_TOUCH(AfterTouch) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::POLY_TOUCH(PolyTouch) => {
+                            eventlist.append(*currentevent);
+                        },
+                    }
+                },
+                Option::None(_) => {
+                    break;
+                }
+            };
+        };
+
+        Midi { events: eventlist.span() }
     }
 
     fn arpeggiate_chords(self: @Midi, pattern: ArpPattern) -> Midi {

--- a/src/midi/modes.cairo
+++ b/src/midi/modes.cairo
@@ -1,5 +1,5 @@
 use array::ArrayTrait;
-
+use koji::midi::types::Modes;
 //**********************************************************************************************************
 //  Mode & Key Definitions
 //
@@ -168,4 +168,21 @@ fn pentatonic_steps() -> Span<u8> {
     mode.append(3);
 
     mode.span()
+}
+
+fn mode_steps(mode: Modes) -> Span<u8> {
+    match mode {
+        Modes::Major => major_steps(),
+        Modes::Minor => minor_steps(),
+        Modes::Lydian => lydian_steps(),
+        Modes::Mixolydian => mixolydian_steps(),
+        Modes::Dorian => dorian_steps(),
+        Modes::Phrygian => phrygian_steps(),
+        Modes::Locrian => locrian_steps(),
+        Modes::Aeolian => aeolian_steps(),
+        Modes::Harmonicminor => harmonicminor_steps(),
+        Modes::Naturalminor => naturalminor_steps(),
+        Modes::Chromatic => chromatic_steps(),
+        Modes::Pentatonic => pentatonic_steps(),
+    }
 }

--- a/src/midi/pitch.cairo
+++ b/src/midi/pitch.cairo
@@ -7,8 +7,8 @@ use traits::TryInto;
 use traits::Into;
 use debug::PrintTrait;
 
-use koji::midi::types::{PitchClass, OCTAVEBASE, Direction, Quality};
-use koji::midi::modes::{Modes};
+use koji::midi::types::{Modes, PitchClass, OCTAVEBASE, Direction, Quality};
+use koji::midi::modes::{mode_steps};
 
 //*****************************************************************************************************************
 // PitchClass and Note Utils 
@@ -98,19 +98,20 @@ fn diff_between_pc(pc1: PitchClass, pc2: PitchClass) -> (u8, Direction) {
     }
 }
 
+//Provide Array, Compute and Return notes of mode at note base - note base is omitted
 fn mode_notes_above_note_base(mut arr: Span<u8>, mut new_arr: Array<u8>, note: u8) -> Span<u8> {
-    let mut new_note = note;
+    let mut new_note: u8 = note;
 
     loop {
         match arr.pop_front() {
             Option::Some(current_note) => {
-                new_note = (current_note + new_note) % OCTAVEBASE;
+                new_note = (*current_note + new_note) % OCTAVEBASE;
                 new_arr.append(new_note);
             },
             Option::None(_) => {
                 break;
             }
-        }
+        };
     };
 
     new_arr.span()
@@ -118,19 +119,19 @@ fn mode_notes_above_note_base(mut arr: Span<u8>, mut new_arr: Array<u8>, note: u
 
 fn mode_notes_above_note_base2(pc: PitchClass, pcoll: Span<u8>) -> Span<u8> {
     let mut outarr = ArrayTrait::new();
-
+let mut pcollection =  pcoll.clone();
     let mut sum = pc.note;
 
     loop {
-        match pcoll.pop_front() {
+        match pcollection.pop_front() {
             Option::Some(step) => {
-                sum += step;
+                sum += *step;
                 outarr.append(sum % OCTAVEBASE);
             },
             Option::None(_) => {
                 break;
             }
-        }
+        };
     };
 
     outarr.span()
@@ -148,23 +149,25 @@ fn get_notes_of_key(tonic: u8, mode: Span<u8>) -> Span<u8> {
 // Functions that compute collect notes of a mode at a specified pitch base in Normal Form (% OCTAVEBASE)
 // Example: E Major -> [1,3,4,6,8,9,11]  (C#,D#,E,F#,G#,A,B)
 
-fn get_notes_of_key2(pc: PitchClass, mut pcoll: Span<u8>) -> Span<u8> {
+fn get_notes_of_key2(pc: PitchClass, pcoll: Span<u8>) -> Span<u8> {
     let mut outarr = ArrayTrait::<u8>::new();
+let mut pcollection =  pcoll.clone();
 
     let mut sum = pc.note;
+    let mut i = 0;
 
     outarr.append(sum);
 
     loop {
-        match pcoll.pop_front() {
+        match pcollection.pop_front() {
             Option::Some(step) => {
-                sum += step;
+                sum += *step;
                 outarr.append(sum % OCTAVEBASE);
             },
             Option::None(_) => {
                 break;
             }
-        }
+        };
     };
 
     outarr.span()
@@ -174,24 +177,27 @@ fn get_notes_of_key2(pc: PitchClass, mut pcoll: Span<u8>) -> Span<u8> {
 // In this implementation, Scale degrees doesn't use zero-based counting - Zero if the note is note present in the key.
 // Perhaps implement Option for when a note is not a scale degree          
 
-fn get_scale_degree(pc: PitchClass, tonic: PitchClass, mut pcoll: Span<u8>) -> u8 {
+fn get_scale_degree(pc: PitchClass, tonic: PitchClass, pcoll: Span<u8>) -> u8 {
     let mut notesofkey = tonic.get_notes_of_key(pcoll.snapshot.clone().span());
+    let mut i = 0;
     let mut outdegree = 0;
 
     loop {
         match notesofkey.pop_front() {
             Option::Some(note) => {
-                if pc.note == note {
-                    outdegree = notesofkey.len() as u8 + 1;
+                if pc.note == *note {
+                    outdegree += notesofkey.len() + 1;
                 }
             },
             Option::None(_) => {
                 break;
             }
-        }
+        };
     };
 
-    outdegree
+    let scaledegree: u8 = outdegree.try_into().unwrap();
+
+    scaledegree
 }
 
 fn modal_transposition(

--- a/src/midi/pitch.cairo
+++ b/src/midi/pitch.cairo
@@ -42,10 +42,10 @@ impl PitchClassImpl of PitchClassTrait {
         abs_diff_between_pc(*self, pc2)
     }
     fn mode_notes_above_note_base(self: @PitchClass, pcoll: Span<u8>) -> Span<u8> {
-        mode_notes_above_note_base2(*self, pcoll)
+        mode_notes_above_note_base(*self, pcoll)
     }
     fn get_notes_of_key(self: @PitchClass, pcoll: Span<u8>) -> Span<u8> {
-        get_notes_of_key2(*self, pcoll)
+        get_notes_of_key(*self, pcoll)
     }
     fn get_scale_degree(self: @PitchClass, tonic: PitchClass, pcoll: Span<u8>) -> u8 {
         get_scale_degree(*self, tonic, pcoll)
@@ -99,34 +99,18 @@ fn diff_between_pc(pc1: PitchClass, pc2: PitchClass) -> (u8, Direction) {
 }
 
 //Provide Array, Compute and Return notes of mode at note base - note base is omitted
-fn mode_notes_above_note_base(mut arr: Span<u8>, mut new_arr: Array<u8>, note: u8) -> Span<u8> {
-    let mut new_note: u8 = note;
 
-    loop {
-        match arr.pop_front() {
-            Option::Some(current_note) => {
-                new_note = (*current_note + new_note) % OCTAVEBASE;
-                new_arr.append(new_note);
-            },
-            Option::None(_) => {
-                break;
-            }
-        };
-    };
-
-    new_arr.span()
-}
-
-fn mode_notes_above_note_base2(pc: PitchClass, pcoll: Span<u8>) -> Span<u8> {
+fn mode_notes_above_note_base(pc: PitchClass, pcoll: Span<u8>) -> Span<u8> {
     let mut outarr = ArrayTrait::new();
-let mut pcollection =  pcoll.clone();
-    let mut sum = pc.note;
+    let mut pcollection = pcoll.clone();
+    let pcnote = pc.note;
+    let mut sum = 0;
 
     loop {
         match pcollection.pop_front() {
             Option::Some(step) => {
                 sum += *step;
-                outarr.append(sum % OCTAVEBASE);
+                outarr.append((pcnote + sum) % OCTAVEBASE);
             },
             Option::None(_) => {
                 break;
@@ -139,19 +123,10 @@ let mut pcollection =  pcoll.clone();
 
 // Functions that compute collect notes of a mode at a specified pitch base in Normal Form (% OCTAVEBASE)
 // Example: E Major -> [1,3,4,6,8,9,11]  (C#,D#,E,F#,G#,A,B)
-fn get_notes_of_key(tonic: u8, mode: Span<u8>) -> Span<u8> {
-    let tonic_note = tonic % OCTAVEBASE;
-    let mut new_arr = ArrayTrait::<u8>::new();
-    new_arr.append(tonic_note);
-    mode_notes_above_note_base(mode, new_arr, tonic)
-}
 
-// Functions that compute collect notes of a mode at a specified pitch base in Normal Form (% OCTAVEBASE)
-// Example: E Major -> [1,3,4,6,8,9,11]  (C#,D#,E,F#,G#,A,B)
-
-fn get_notes_of_key2(pc: PitchClass, pcoll: Span<u8>) -> Span<u8> {
+fn get_notes_of_key(pc: PitchClass, pcoll: Span<u8>) -> Span<u8> {
     let mut outarr = ArrayTrait::<u8>::new();
-let mut pcollection =  pcoll.clone();
+    let mut pcollection = pcoll.clone();
 
     let mut sum = pc.note;
     let mut i = 0;
@@ -179,6 +154,7 @@ let mut pcollection =  pcoll.clone();
 
 fn get_scale_degree(pc: PitchClass, tonic: PitchClass, pcoll: Span<u8>) -> u8 {
     let mut notesofkey = tonic.get_notes_of_key(pcoll.snapshot.clone().span());
+    let notesofkeylen = notesofkey.len();
     let mut i = 0;
     let mut outdegree = 0;
 
@@ -186,7 +162,10 @@ fn get_scale_degree(pc: PitchClass, tonic: PitchClass, pcoll: Span<u8>) -> u8 {
         match notesofkey.pop_front() {
             Option::Some(note) => {
                 if pc.note == *note {
-                    outdegree += notesofkey.len() + 1;
+                    outdegree = notesofkeylen - notesofkey.len();
+                    if (outdegree == notesofkeylen) {
+                        outdegree = 1;
+                    };
                 }
             },
             Option::None(_) => {

--- a/src/midi/types.cairo
+++ b/src/midi/types.cairo
@@ -1,5 +1,9 @@
 use orion::numbers::{FP32x32, i32};
-
+use koji::midi::modes::{
+    major_steps, minor_steps, lydian_steps, mixolydian_steps, dorian_steps, phrygian_steps,
+    locrian_steps, aeolian_steps, harmonicminor_steps, naturalminor_steps, chromatic_steps,
+    pentatonic_steps
+};
 /// =========================================
 /// ================ MIDI ===================
 /// =========================================


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Lots of changes and bug fixes to implement generate-harmony that creates a new Midi with notes harmonized n steps above or below at a given tonic/pitchbase and Mode. Includes both the harmony and existing melody. 

I fixed a few bugs in PitchClass so that should compile fine now once this is merged. I have a ton of tests that I will load up as well.

Please check the type of change your PR introduces:

- [X] Bugfix
- [X] Feature
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #12 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added mode_steps function for mapping Modes variants to respective step arrays
- Fixed bugs in Pitch Class that caused compilation errors 
- Implemented generate-harmony

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->