### PR TITLE
VelocityCurve implementation

### DIFF
--- a/src/midi.cairo
+++ b/src/midi.cairo
@@ -4,3 +4,4 @@ mod instruments;
 mod time;
 mod modes;
 mod pitch;
+mod velocitycurve;

--- a/src/midi/types.cairo
+++ b/src/midi/types.cairo
@@ -115,8 +115,12 @@ enum Modes {
 #[derive(Copy, Drop)]
 enum ArpPattern {} //TODO
 
+// VelocityCurve represents time & level "breakpoint" pairs indexed:
 #[derive(Copy, Drop)]
-struct VelocityCurve {} // TODO
+struct VelocityCurve {
+    times: Span<FP32x32>,
+    levels: Span<u8>
+}
 
 /// =========================================
 /// ============== PitchClass ===============

--- a/src/midi/velocitycurve.cairo
+++ b/src/midi/velocitycurve.cairo
@@ -1,0 +1,37 @@
+use orion::operators::tensor::{Tensor, U32Tensor,};
+use orion::numbers::{i32, FP32x32};
+use core::option::OptionTrait;
+use koji::midi::types::{
+    Midi, Message, Modes, ArpPattern, VelocityCurve, NoteOn, NoteOff, SetTempo, TimeSignature,
+    ControlChange, PitchWheel, AfterTouch, PolyTouch, Direction, PitchClass
+};
+
+fn linear_interpolation(
+    x1: FP32x32, y1: FP32x32, x2: FP32x32, y2: FP32x32, xindex: FP32x32
+) -> Option<FP32x32> {
+    if (x1 >= xindex) {
+        Option::None
+    } else if (x1 == x2) {
+        Option::None
+    } else {
+        let mut interpolatedy = y1 + ((y2 - y1) / (x2 - x1)) * (xindex - x1);
+        Option::Some(interpolatedy)
+    }
+}
+
+fn vc_linear_interpolation(
+    x1: FP32x32, y1: u8, x2: FP32x32, y2: u8, xindex: FP32x32
+) -> Option<u8> {
+    let newx1: u8 = x1.mag.try_into().unwrap();
+    let newx2: u8 = x2.mag.try_into().unwrap();
+    let newxindex: u8 = xindex.mag.try_into().unwrap();
+    if (newx1 >= newxindex) {
+        Option::None
+    } else if (newx1 == newx2) {
+        Option::None
+    } else {
+        let mut interpolatedy = y1 + ((y2 - y1) / (newx2 - newx1)) * (newxindex - newx1);
+        Option::Some(interpolatedy)
+    }
+}
+

--- a/src/midi/velocitycurve.cairo
+++ b/src/midi/velocitycurve.cairo
@@ -13,6 +13,10 @@ trait VelocityCurveTrait {
     /// Append a breakpoint time/value pair in a VelocityCurve object.
     fn set_breakpoint_pair(self: @VelocityCurve, time: FP32x32, value: u8) -> VelocityCurve;
     /// =========== GLOBAL MANIPULATION ===========
+    /// Stretch or shrink time values by a specified factor.
+    fn scale_times(self: @VelocityCurve, factor: FP32x32) -> VelocityCurve;
+    /// Add or subtract to time values by a specified offset.
+    fn offset_times(self: @VelocityCurve, factor: FP32x32) -> VelocityCurve;
     /// Stretch or shrink levels by a specified factor.
     fn scale_levels(self: @VelocityCurve, factor: u8) -> VelocityCurve;
     /// Add or subtract to levels by a specified offset.
@@ -54,6 +58,52 @@ impl VelocityCurveImpl of VelocityCurveTrait {
                     vclevels.append(value);
                     break;
                 }
+            };
+        };
+
+        VelocityCurve { times: vctimes.span(), levels: vclevels.span() }
+    }
+    fn offset_times(self: @VelocityCurve, factor: FP32x32) -> VelocityCurve {
+        let mut vct = self.clone().times;
+        let mut vcl = self.clone().levels;
+
+        let mut vctimes = ArrayTrait::<FP32x32>::new();
+        let mut vclevels = ArrayTrait::<u8>::new();
+
+        loop {
+            match vct.pop_front() {
+                Option::Some(currtime) => { vctimes.append(*currtime + factor); },
+                Option::None(_) => { break; }
+            };
+        };
+
+        loop {
+            match vcl.pop_front() {
+                Option::Some(currlevels) => { vclevels.append(*currlevels); },
+                Option::None(_) => { break; }
+            };
+        };
+
+        VelocityCurve { times: vctimes.span(), levels: vclevels.span() }
+    }
+    fn scale_times(self: @VelocityCurve, factor: FP32x32) -> VelocityCurve {
+        let mut vct = self.clone().times;
+        let mut vcl = self.clone().levels;
+
+        let mut vctimes = ArrayTrait::<FP32x32>::new();
+        let mut vclevels = ArrayTrait::<u8>::new();
+
+        loop {
+            match vct.pop_front() {
+                Option::Some(currtime) => { vctimes.append(*currtime * factor); },
+                Option::None(_) => { break; }
+            };
+        };
+
+        loop {
+            match vcl.pop_front() {
+                Option::Some(currlevels) => { vclevels.append(*currlevels); },
+                Option::None(_) => { break; }
             };
         };
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
[Here](https://github.com/cienicera/Koji/blob/velocitycurve/src/midi/velocitycurve.cairo) is the initial implementation of Velocity Curve. It's a breakpoint pattern of arrays of  'time' & 'level' pairs, like an envelope. The main function is getlevelattime which returns the linearly interpolated at a specified time index for use in edit_dynamics. There are also some transfomation functions that will come in handy as well. A part of me wonders if this should be an abstract Envelope or Breakpoint struct so that they could be used for velocity changes as well as pitch or time changes etc. 

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->