### PR TITLE
edit_dynamics

### DIFF
--- a/src/midi.cairo
+++ b/src/midi.cairo
@@ -4,3 +4,4 @@ mod instruments;
 mod time;
 mod modes;
 mod pitch;
+mod velocitycurve;

--- a/src/midi/core.cairo
+++ b/src/midi/core.cairo
@@ -15,6 +15,7 @@ use koji::midi::instruments::{
 use koji::midi::time::round_to_nearest_nth;
 use koji::midi::modes::{mode_steps};
 use koji::midi::pitch::{PitchClassTrait, keynum_to_pc};
+use koji::midi::velocitycurve::{VelocityCurveTrait};
 
 trait MidiTrait {
     /// =========== NOTE MANIPULATION ===========
@@ -61,12 +62,8 @@ impl MidiImpl of MidiTrait {
 
         loop {
             match ev.pop_front() {
-                Option::Some(currentevent) => {
-                    output.append(*currentevent);
-                },
-                Option::None(_) => {
-                    break;
-                },
+                Option::Some(currentevent) => { output.append(*currentevent); },
+                Option::None(_) => { break; },
             };
         };
 
@@ -114,29 +111,19 @@ impl MidiImpl of MidiTrait {
                             let notemessage = Message::NOTE_OFF((newnote));
                             eventlist.append(notemessage);
                         },
-                        Message::SET_TEMPO(SetTempo) => {
-                            eventlist.append(*currentevent);
-                        },
+                        Message::SET_TEMPO(SetTempo) => { eventlist.append(*currentevent); },
                         Message::TIME_SIGNATURE(TimeSignature) => {
                             eventlist.append(*currentevent);
                         },
                         Message::CONTROL_CHANGE(ControlChange) => {
                             eventlist.append(*currentevent);
                         },
-                        Message::PITCH_WHEEL(PitchWheel) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::AFTER_TOUCH(AfterTouch) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::POLY_TOUCH(PolyTouch) => {
-                            eventlist.append(*currentevent);
-                        },
+                        Message::PITCH_WHEEL(PitchWheel) => { eventlist.append(*currentevent); },
+                        Message::AFTER_TOUCH(AfterTouch) => { eventlist.append(*currentevent); },
+                        Message::POLY_TOUCH(PolyTouch) => { eventlist.append(*currentevent); },
                     }
                 },
-                Option::None(_) => {
-                    break;
-                }
+                Option::None(_) => { break; }
             };
         };
 
@@ -156,40 +143,24 @@ impl MidiImpl of MidiTrait {
         match lastmsgtime {
             Option::Some(currentev) => {
                 match currentev {
-                    Message::NOTE_ON(NoteOn) => {
-                        maxtime = *NoteOn.time;
-                    },
-                    Message::NOTE_OFF(NoteOff) => {
-                        maxtime = *NoteOff.time;
-                    },
+                    Message::NOTE_ON(NoteOn) => { maxtime = *NoteOn.time; },
+                    Message::NOTE_OFF(NoteOff) => { maxtime = *NoteOff.time; },
                     Message::SET_TEMPO(SetTempo) => {
                         match *SetTempo.time {
-                            Option::Some(time) => {
-                                maxtime = time;
-                            },
+                            Option::Some(time) => { maxtime = time; },
                             Option::None => {},
                         }
                     },
                     Message::TIME_SIGNATURE(TimeSignature) => {
                         match *TimeSignature.time {
-                            Option::Some(time) => {
-                                maxtime = time;
-                            },
+                            Option::Some(time) => { maxtime = time; },
                             Option::None => {},
                         }
                     },
-                    Message::CONTROL_CHANGE(ControlChange) => {
-                        maxtime = *ControlChange.time;
-                    },
-                    Message::PITCH_WHEEL(PitchWheel) => {
-                        maxtime = *PitchWheel.time;
-                    },
-                    Message::AFTER_TOUCH(AfterTouch) => {
-                        maxtime = *AfterTouch.time;
-                    },
-                    Message::POLY_TOUCH(PolyTouch) => {
-                        maxtime = *PolyTouch.time;
-                    },
+                    Message::CONTROL_CHANGE(ControlChange) => { maxtime = *ControlChange.time; },
+                    Message::PITCH_WHEEL(PitchWheel) => { maxtime = *PitchWheel.time; },
+                    Message::AFTER_TOUCH(AfterTouch) => { maxtime = *AfterTouch.time; },
+                    Message::POLY_TOUCH(PolyTouch) => { maxtime = *PolyTouch.time; },
                 }
             },
             Option::None(_) => {}
@@ -199,40 +170,24 @@ impl MidiImpl of MidiTrait {
         match firstmsgtime {
             Option::Some(currentev) => {
                 match currentev {
-                    Message::NOTE_ON(NoteOn) => {
-                        mintime = *NoteOn.time;
-                    },
-                    Message::NOTE_OFF(NoteOff) => {
-                        mintime = *NoteOff.time;
-                    },
+                    Message::NOTE_ON(NoteOn) => { mintime = *NoteOn.time; },
+                    Message::NOTE_OFF(NoteOff) => { mintime = *NoteOff.time; },
                     Message::SET_TEMPO(SetTempo) => {
                         match *SetTempo.time {
-                            Option::Some(time) => {
-                                mintime = time;
-                            },
+                            Option::Some(time) => { mintime = time; },
                             Option::None => {},
                         }
                     },
                     Message::TIME_SIGNATURE(TimeSignature) => {
                         match *TimeSignature.time {
-                            Option::Some(time) => {
-                                mintime = time;
-                            },
+                            Option::Some(time) => { mintime = time; },
                             Option::None => {},
                         }
                     },
-                    Message::CONTROL_CHANGE(ControlChange) => {
-                        mintime = *ControlChange.time;
-                    },
-                    Message::PITCH_WHEEL(PitchWheel) => {
-                        mintime = *PitchWheel.time;
-                    },
-                    Message::AFTER_TOUCH(AfterTouch) => {
-                        mintime = *AfterTouch.time;
-                    },
-                    Message::POLY_TOUCH(PolyTouch) => {
-                        mintime = *PolyTouch.time;
-                    },
+                    Message::CONTROL_CHANGE(ControlChange) => { mintime = *ControlChange.time; },
+                    Message::PITCH_WHEEL(PitchWheel) => { mintime = *PitchWheel.time; },
+                    Message::AFTER_TOUCH(AfterTouch) => { mintime = *AfterTouch.time; },
+                    Message::POLY_TOUCH(PolyTouch) => { mintime = *PolyTouch.time; },
                 }
             },
             Option::None(_) => {}
@@ -326,9 +281,7 @@ impl MidiImpl of MidiTrait {
                         },
                     }
                 },
-                Option::None(_) => {
-                    break;
-                }
+                Option::None(_) => { break; }
             };
         };
 
@@ -363,29 +316,19 @@ impl MidiImpl of MidiTrait {
                             let notemessage = Message::NOTE_OFF((newnote));
                             eventlist.append(notemessage);
                         },
-                        Message::SET_TEMPO(SetTempo) => {
-                            eventlist.append(*currentevent)
-                        },
+                        Message::SET_TEMPO(SetTempo) => { eventlist.append(*currentevent) },
                         Message::TIME_SIGNATURE(TimeSignature) => {
                             eventlist.append(*currentevent)
                         },
                         Message::CONTROL_CHANGE(ControlChange) => {
                             eventlist.append(*currentevent)
                         },
-                        Message::PITCH_WHEEL(PitchWheel) => {
-                            eventlist.append(*currentevent)
-                        },
-                        Message::AFTER_TOUCH(AfterTouch) => {
-                            eventlist.append(*currentevent)
-                        },
-                        Message::POLY_TOUCH(PolyTouch) => {
-                            eventlist.append(*currentevent)
-                        },
+                        Message::PITCH_WHEEL(PitchWheel) => { eventlist.append(*currentevent) },
+                        Message::AFTER_TOUCH(AfterTouch) => { eventlist.append(*currentevent) },
+                        Message::POLY_TOUCH(PolyTouch) => { eventlist.append(*currentevent) },
                     }
                 },
-                Option::None(_) => {
-                    break;
-                }
+                Option::None(_) => { break; }
             };
         };
 
@@ -435,9 +378,7 @@ impl MidiImpl of MidiTrait {
                         Message::POLY_TOUCH(PolyTouch) => {},
                     }
                 },
-                Option::None(_) => {
-                    break;
-                }
+                Option::None(_) => { break; }
             };
         };
 
@@ -539,9 +480,7 @@ impl MidiImpl of MidiTrait {
                         },
                     }
                 },
-                Option::None(_) => {
-                    break;
-                }
+                Option::None(_) => { break; }
             };
         };
 
@@ -562,12 +501,8 @@ impl MidiImpl of MidiTrait {
                 Option::Some(currentevent) => {
                     // Process the current event
                     match currentevent {
-                        Message::NOTE_ON(NoteOn) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::NOTE_OFF(NoteOff) => {
-                            eventlist.append(*currentevent);
-                        },
+                        Message::NOTE_ON(NoteOn) => { eventlist.append(*currentevent); },
+                        Message::NOTE_OFF(NoteOff) => { eventlist.append(*currentevent); },
                         Message::SET_TEMPO(SetTempo) => {
                             // Create a new SetTempo message with the updated tempo
                             let tempo = SetTempo { tempo: new_tempo, time: *SetTempo.time };
@@ -580,15 +515,9 @@ impl MidiImpl of MidiTrait {
                         Message::CONTROL_CHANGE(ControlChange) => {
                             eventlist.append(*currentevent);
                         },
-                        Message::PITCH_WHEEL(PitchWheel) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::AFTER_TOUCH(AfterTouch) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::POLY_TOUCH(PolyTouch) => {
-                            eventlist.append(*currentevent);
-                        },
+                        Message::PITCH_WHEEL(PitchWheel) => { eventlist.append(*currentevent); },
+                        Message::AFTER_TOUCH(AfterTouch) => { eventlist.append(*currentevent); },
+                        Message::POLY_TOUCH(PolyTouch) => { eventlist.append(*currentevent); },
                     }
                 },
                 Option::None(_) => {
@@ -615,12 +544,8 @@ impl MidiImpl of MidiTrait {
                 Option::Some(currentevent) => {
                     // Process the current event
                     match currentevent {
-                        Message::NOTE_ON(NoteOn) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::NOTE_OFF(NoteOff) => {
-                            eventlist.append(*currentevent);
-                        },
+                        Message::NOTE_ON(NoteOn) => { eventlist.append(*currentevent); },
+                        Message::NOTE_OFF(NoteOff) => { eventlist.append(*currentevent); },
                         Message::SET_TEMPO(SetTempo) => {
                             // Create a new SetTempo message with the updated tempo
                             eventlist.append(*currentevent);
@@ -637,15 +562,9 @@ impl MidiImpl of MidiTrait {
                             };
                             eventlist.append(Message::CONTROL_CHANGE((outcc)));
                         },
-                        Message::PITCH_WHEEL(PitchWheel) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::AFTER_TOUCH(AfterTouch) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::POLY_TOUCH(PolyTouch) => {
-                            eventlist.append(*currentevent);
-                        },
+                        Message::PITCH_WHEEL(PitchWheel) => { eventlist.append(*currentevent); },
+                        Message::AFTER_TOUCH(AfterTouch) => { eventlist.append(*currentevent); },
+                        Message::POLY_TOUCH(PolyTouch) => { eventlist.append(*currentevent); },
                     }
                 },
                 Option::None(_) => {
@@ -670,9 +589,7 @@ impl MidiImpl of MidiTrait {
                     match currentevent {
                         Message::NOTE_ON(NoteOn) => {},
                         Message::NOTE_OFF(NoteOff) => {},
-                        Message::SET_TEMPO(SetTempo) => {
-                            outtempo = *SetTempo.tempo;
-                        },
+                        Message::SET_TEMPO(SetTempo) => { outtempo = *SetTempo.tempo; },
                         Message::TIME_SIGNATURE(TimeSignature) => {},
                         Message::CONTROL_CHANGE(ControlChange) => {},
                         Message::PITCH_WHEEL(PitchWheel) => {},
@@ -680,9 +597,7 @@ impl MidiImpl of MidiTrait {
                         Message::POLY_TOUCH(PolyTouch) => {},
                     }
                 },
-                Option::None(_) => {
-                    break;
-                }
+                Option::None(_) => { break; }
             };
         };
 
@@ -748,29 +663,19 @@ impl MidiImpl of MidiTrait {
                             //include original note
                             eventlist.append(*currentevent);
                         },
-                        Message::SET_TEMPO(SetTempo) => {
-                            eventlist.append(*currentevent);
-                        },
+                        Message::SET_TEMPO(SetTempo) => { eventlist.append(*currentevent); },
                         Message::TIME_SIGNATURE(TimeSignature) => {
                             eventlist.append(*currentevent);
                         },
                         Message::CONTROL_CHANGE(ControlChange) => {
                             eventlist.append(*currentevent);
                         },
-                        Message::PITCH_WHEEL(PitchWheel) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::AFTER_TOUCH(AfterTouch) => {
-                            eventlist.append(*currentevent);
-                        },
-                        Message::POLY_TOUCH(PolyTouch) => {
-                            eventlist.append(*currentevent);
-                        },
+                        Message::PITCH_WHEEL(PitchWheel) => { eventlist.append(*currentevent); },
+                        Message::AFTER_TOUCH(AfterTouch) => { eventlist.append(*currentevent); },
+                        Message::POLY_TOUCH(PolyTouch) => { eventlist.append(*currentevent); },
                     }
                 },
-                Option::None(_) => {
-                    break;
-                }
+                Option::None(_) => { break; }
             };
         };
 
@@ -782,6 +687,60 @@ impl MidiImpl of MidiTrait {
     }
 
     fn edit_dynamics(self: @Midi, curve: VelocityCurve) -> Midi {
-        panic(array!['not supported yet'])
+        let mut ev = self.clone().events;
+        let mut vcurve = curve.clone();
+        let mut outvelocity = 0;
+        let mut eventlist = ArrayTrait::<Message>::new();
+
+        loop {
+            match ev.pop_front() {
+                Option::Some(currentevent) => {
+                    match currentevent {
+                        Message::NOTE_ON(NoteOn) => {
+                            match vcurve.getlevelattime(*NoteOn.time) {
+                                Option::Some(val) => { outvelocity = val; },
+                                Option::None => { outvelocity = *NoteOn.velocity; }
+                            }
+
+                            let newnote = NoteOn {
+                                channel: *NoteOn.channel,
+                                note: *NoteOn.note,
+                                velocity: outvelocity,
+                                time: *NoteOn.time
+                            };
+                            let notemessage = Message::NOTE_ON((newnote));
+                            eventlist.append(notemessage);
+                        },
+                        Message::NOTE_OFF(NoteOff) => {
+                            match vcurve.getlevelattime(*NoteOff.time) {
+                                Option::Some(val) => { outvelocity = val; },
+                                Option::None => { outvelocity = *NoteOff.velocity; }
+                            }
+                            let newnote = NoteOff {
+                                channel: *NoteOff.channel,
+                                note: *NoteOff.note,
+                                velocity: outvelocity,
+                                time: *NoteOff.time
+                            };
+                            let notemessage = Message::NOTE_OFF((newnote));
+                            eventlist.append(notemessage);
+                        },
+                        Message::SET_TEMPO(SetTempo) => { eventlist.append(*currentevent); },
+                        Message::TIME_SIGNATURE(TimeSignature) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::CONTROL_CHANGE(ControlChange) => {
+                            eventlist.append(*currentevent);
+                        },
+                        Message::PITCH_WHEEL(PitchWheel) => { eventlist.append(*currentevent); },
+                        Message::AFTER_TOUCH(AfterTouch) => { eventlist.append(*currentevent); },
+                        Message::POLY_TOUCH(PolyTouch) => { eventlist.append(*currentevent); },
+                    }
+                },
+                Option::None(_) => { break; }
+            };
+        };
+
+        Midi { events: eventlist.span() }
     }
 }

--- a/src/midi/types.cairo
+++ b/src/midi/types.cairo
@@ -115,8 +115,12 @@ enum Modes {
 #[derive(Copy, Drop)]
 enum ArpPattern {} //TODO
 
+// VelocityCurve represents time & level "breakpoint" pairs indexed:
 #[derive(Copy, Drop)]
-struct VelocityCurve {} // TODO
+struct VelocityCurve {
+    times: Span<FP32x32>,
+    levels: Span<u8>
+}
 
 /// =========================================
 /// ============== PitchClass ===============

--- a/src/midi/velocitycurve.cairo
+++ b/src/midi/velocitycurve.cairo
@@ -1,0 +1,37 @@
+use orion::operators::tensor::{Tensor, U32Tensor,};
+use orion::numbers::{i32, FP32x32};
+use core::option::OptionTrait;
+use koji::midi::types::{
+    Midi, Message, Modes, ArpPattern, VelocityCurve, NoteOn, NoteOff, SetTempo, TimeSignature,
+    ControlChange, PitchWheel, AfterTouch, PolyTouch, Direction, PitchClass
+};
+
+fn linear_interpolation(
+    x1: FP32x32, y1: FP32x32, x2: FP32x32, y2: FP32x32, xindex: FP32x32
+) -> Option<FP32x32> {
+    if (x1 >= xindex) {
+        Option::None
+    } else if (x1 == x2) {
+        Option::None
+    } else {
+        let mut interpolatedy = y1 + ((y2 - y1) / (x2 - x1)) * (xindex - x1);
+        Option::Some(interpolatedy)
+    }
+}
+
+fn vc_linear_interpolation(
+    x1: FP32x32, y1: u8, x2: FP32x32, y2: u8, xindex: FP32x32
+) -> Option<u8> {
+    let newx1: u8 = x1.mag.try_into().unwrap();
+    let newx2: u8 = x2.mag.try_into().unwrap();
+    let newxindex: u8 = xindex.mag.try_into().unwrap();
+    if (newx1 >= newxindex) {
+        Option::None
+    } else if (newx1 == newx2) {
+        Option::None
+    } else {
+        let mut interpolatedy = y1 + ((y2 - y1) / (newx2 - newx1)) * (newxindex - newx1);
+        Option::Some(interpolatedy)
+    }
+}
+

--- a/src/midi/velocitycurve.cairo
+++ b/src/midi/velocitycurve.cairo
@@ -13,6 +13,10 @@ trait VelocityCurveTrait {
     /// Append a breakpoint time/value pair in a VelocityCurve object.
     fn set_breakpoint_pair(self: @VelocityCurve, time: FP32x32, value: u8) -> VelocityCurve;
     /// =========== GLOBAL MANIPULATION ===========
+    /// Stretch or shrink time values by a specified factor.
+    fn scale_times(self: @VelocityCurve, factor: FP32x32) -> VelocityCurve;
+    /// Add or subtract to time values by a specified offset.
+    fn offset_times(self: @VelocityCurve, factor: FP32x32) -> VelocityCurve;
     /// Stretch or shrink levels by a specified factor.
     fn scale_levels(self: @VelocityCurve, factor: u8) -> VelocityCurve;
     /// Add or subtract to levels by a specified offset.
@@ -54,6 +58,52 @@ impl VelocityCurveImpl of VelocityCurveTrait {
                     vclevels.append(value);
                     break;
                 }
+            };
+        };
+
+        VelocityCurve { times: vctimes.span(), levels: vclevels.span() }
+    }
+    fn offset_times(self: @VelocityCurve, factor: FP32x32) -> VelocityCurve {
+        let mut vct = self.clone().times;
+        let mut vcl = self.clone().levels;
+
+        let mut vctimes = ArrayTrait::<FP32x32>::new();
+        let mut vclevels = ArrayTrait::<u8>::new();
+
+        loop {
+            match vct.pop_front() {
+                Option::Some(currtime) => { vctimes.append(*currtime + factor); },
+                Option::None(_) => { break; }
+            };
+        };
+
+        loop {
+            match vcl.pop_front() {
+                Option::Some(currlevels) => { vclevels.append(*currlevels); },
+                Option::None(_) => { break; }
+            };
+        };
+
+        VelocityCurve { times: vctimes.span(), levels: vclevels.span() }
+    }
+    fn scale_times(self: @VelocityCurve, factor: FP32x32) -> VelocityCurve {
+        let mut vct = self.clone().times;
+        let mut vcl = self.clone().levels;
+
+        let mut vctimes = ArrayTrait::<FP32x32>::new();
+        let mut vclevels = ArrayTrait::<u8>::new();
+
+        loop {
+            match vct.pop_front() {
+                Option::Some(currtime) => { vctimes.append(*currtime * factor); },
+                Option::None(_) => { break; }
+            };
+        };
+
+        loop {
+            match vcl.pop_front() {
+                Option::Some(currlevels) => { vclevels.append(*currlevels); },
+                Option::None(_) => { break; }
             };
         };
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
[Here](https://github.com/cienicera/Koji/blob/6358765f637aeb9a029fba15b5525ab36f9c67c2/src/midi/core.cairo#L689) is the implementation for edit_dynamics. The function iterates over each noteOn/noteOff's time messages, indexes that time value into a VelocityCurve and gets the linearly interpolated level that is used to scale the note's velocity.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->