### PR TITLE
Pitchclass 2 frequency

### DIFF
--- a/src/midi/pitch.cairo
+++ b/src/midi/pitch.cairo
@@ -10,6 +10,9 @@ use debug::PrintTrait;
 use koji::midi::types::{Modes, PitchClass, OCTAVEBASE, Direction, Quality};
 use koji::midi::modes::{mode_steps};
 
+use orion::numbers::{i32, FP32x32, FP32x32Impl, FixedTrait};
+
+
 //*****************************************************************************************************************
 // PitchClass and Note Utils 
 //
@@ -25,6 +28,7 @@ use koji::midi::modes::{mode_steps};
 
 trait PitchClassTrait {
     fn keynum(self: @PitchClass) -> u8;
+    fn freq(self: @PitchClass) -> u32;
     fn abs_diff_between_pc(self: @PitchClass, pc2: PitchClass) -> u8;
     fn mode_notes_above_note_base(self: @PitchClass, pcoll: Span<u8>) -> Span<u8>;
     fn get_notes_of_key(self: @PitchClass, pcoll: Span<u8>) -> Span<u8>;
@@ -37,6 +41,9 @@ trait PitchClassTrait {
 impl PitchClassImpl of PitchClassTrait {
     fn keynum(self: @PitchClass) -> u8 {
         pc_to_keynum(*self)
+    }
+    fn freq(self: @PitchClass) -> u32 {
+        freq(*self)
     }
     fn abs_diff_between_pc(self: @PitchClass, pc2: PitchClass) -> u8 {
         abs_diff_between_pc(*self, pc2)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

This feature implements the conversion from PitchClass/Midikeynums to Frequency (Hz)
[Code here](https://github.com/cienicera/Koji/blob/30c3fb81a453bb08514edc57cfd3328db59bdca3/src/midi/pitch.cairo#L74)

Test cases currently reside [here](https://github.com/cienicera/Koji/issues/43)

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, decimals values aren't being included in the tests printouts. Integer freq calculations work well

Issue Number: #43 

## What is the new behavior?

Now PitchClassTrait can be used in Cairo-Wave creations!
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->