### PR TITLE
Voicing Implementation

### DIFF
--- a/src/midi/types.cairo
+++ b/src/midi/types.cairo
@@ -159,7 +159,7 @@ enum Direction {
 struct PitchInterval {
     size: u8,
     direction: Direction,
-    quality: Quality,
+    quality: Option<Quality>,
 }
 
 #[derive(Copy, Drop)]

--- a/src/midi/voicings.cairo
+++ b/src/midi/voicings.cairo
@@ -1,16 +1,16 @@
 use array::ArrayTrait;
+use koji::midi::types::{PitchInterval, Direction, Quality};
 
 //**********************************************************************************************************
 //  Voicing Definitions
 //
-// We define Voicings as an ordered array of modal steps (or PitchIntervals) from a specified PitchClass and Mode
+// We define Voicings as an ordered array of modal steps (or PitchIntervals) from a specified PitchClass
 //
-// Example 1: first position triad in C Major Key: [2, 2] -> [C, E, G]
-// Example 2: first position triad in C Major 7 Key: [2, 2, 2] -> [C, E, G, B]
+// Example: first position triad in C Major Key: [2 steps Up, 4 steps Up] -> [C, E, G]
 //
 // Current implementation uses modal steps - to do: enable voicings defined as a PitchInterval from a note
 //
-// It is from these defined PitchIntervals that we can compute a chord of a Mode at a given scale degree
+// It is from these defined PitchIntervals that we can compute a chord of a intervals at a given scale degree
 //
 // For microtonal scales, steps should be defined as ratios of BASEOCTAVE
 //
@@ -25,34 +25,89 @@ enum Voicings {
     Tetrad_root_position: (),
 }
 
-fn triad_root_position() -> Span<u8> {
-    let mut mode = ArrayTrait::<u8>::new();
-    mode.append(2);
-    mode.append(2);
-
-    mode.span()
+fn triad_root_position() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 4, direction: Direction::Up(()) });
+    intervals.span()
 }
 
-fn triad_root_position_intervals() -> Span<u8> {
-    let mut mode = ArrayTrait::<u8>::new();
-    mode.append(2);
-    mode.append(2);
-
-    mode.span()
+fn triad_first_inversion() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 5, direction: Direction::Up(()) });
+    intervals.span()
 }
 
-fn triad_first_inversion() -> Span<u8> {
-    let mut mode = ArrayTrait::<u8>::new();
-    mode.append(2);
-    mode.append(3);
-
-    mode.span()
+fn triad_second_inversion() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 3, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 5, direction: Direction::Up(()) });
+    intervals.span()
 }
 
-fn triad_second_inversion() -> Span<u8> {
-    let mut mode = ArrayTrait::<u8>::new();
-    mode.append(3);
-    mode.append(2);
+fn maj_7_no_root_3rd_inversion() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 1, direction: Direction::Down(()) });
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 4, direction: Direction::Up(()) });
+    intervals.span()
+}
 
-    mode.span()
+fn maj_7_no_root_3rd_inversion2() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 1, direction: Direction::Down(()) });
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 4, direction: Direction::Up(()) });
+    intervals.span()
+}
+
+fn maj_7_no_root_3rd_inversion_add6() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 1, direction: Direction::Down(()) });
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 5, direction: Direction::Up(()) });
+    intervals.span()
+}
+
+fn maj_9_no_root_3rd_inversion_add6() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 1, direction: Direction::Down(()) });
+    intervals.append(PitchInterval { size: 1, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 5, direction: Direction::Up(()) });
+    intervals.span()
+}
+
+fn fourths_1() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 1, direction: Direction::Down(()) });
+    intervals.append(PitchInterval { size: 1, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 5, direction: Direction::Up(()) });
+    intervals.span()
+}
+
+fn plus_four_7() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 1, direction: Direction::Down(()) });
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 3, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 5, direction: Direction::Up(()) });
+    intervals.span()
+}
+
+fn plus_four_7_2() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 3, direction: Direction::Up(()) });
+    intervals.append(PitchInterval { size: 6, direction: Direction::Up(()) });
+    intervals.span()
+}
+
+fn seventh_and_third() -> Span<PitchInterval> {
+    let mut intervals = ArrayTrait::<PitchInterval>::new();
+    intervals.append(PitchInterval { size: 1, direction: Direction::Down(()) });
+    intervals.append(PitchInterval { size: 2, direction: Direction::Up(()) });
+    intervals.span()
 }


### PR DESCRIPTION
Implemented Voicing to be defined as an Array of PitchIntervals representing modal steps from a given PitchClass.

Amended PitchInterval to have an Optional quality field.

This will be helpful when we are generating chords from a given PitchClass of different inversion types. This is a vast improvement to our current pattern - It's more optimized than each element in the array being adjacent modal steps.

Example of new Implementation: first position triad for Pitch C, Major Key: [2 steps Up, 4 steps Up] -> [C, E, G]